### PR TITLE
Handle different CSV file encodings

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,7 +73,15 @@ class CollectionDocument:
 
 def load_dataframe(csv_data) -> pd.DataFrame:
     """Loads a Pandas DataFrame from a given file object."""
-    return pd.read_csv(csv_data)
+    encodings = ['utf-8', 'iso-8859-1', 'windows-1252', 'mac_roman', 'ascii']
+    for enc in encodings:
+        try:
+            return pd.read_csv(csv_data, encoding=enc)
+        except (UnicodeDecodeError, FileNotFoundError) as e:
+            print(f"Failed to decode with encoding '{enc}': {e}")
+            continue
+    
+    raise ValueError("Could not decode the CSV file with the provided encodings. Check CSV file encoding.")
 
 
 def preprocess_dataframe(


### PR DESCRIPTION
Currently this app handles only `UTF-8` encoded CSV files, which is fine in many cases.

This change allows to gracefully handle different CSV file encodings in a way that even when you have multiple different files with different encoding it will work well. I added only few most popular, as well some verbose message so any new person can easily add theirs as needed. Another way would be to use some library like `chardet` in Python and detect file encoding but it is not very fast for bigger files.

I stumbled upon this when working with multiple CSV files on MacOS that are MacRoman encoded (especially if you export CSV from some online spreadsheet tools.